### PR TITLE
feat(cart): Add cart management endpoints

### DIFF
--- a/littleLemon/admin.py
+++ b/littleLemon/admin.py
@@ -13,8 +13,14 @@ class CategoryAdmin(admin.ModelAdmin):
     list_display = ('id', 'title', 'slug')
 
 
+class CartAdmin(admin.ModelAdmin):
+    list_display = ('user', 'menuitem', 'quantity', 'unit_price', 'price')
+    list_filter = ('user', 'menuitem')
+    search_fields = ('user__username', 'menuitem__title')
+
+
+admin.site.register(models.Cart, CartAdmin)
 admin.site.register(models.MenuItem, MenuItemAdmin)
 admin.site.register(models.Category, CategoryAdmin)
-admin.site.register(models.Cart)
 admin.site.register(models.Order)
 admin.site.register(models.OrderItem)

--- a/littleLemon/models.py
+++ b/littleLemon/models.py
@@ -18,6 +18,9 @@ class MenuItem(models.Model):
     featured = models.BooleanField(db_index=True)
     category = models.ForeignKey(Category, on_delete=models.PROTECT)
 
+    def __str__(self):
+        return self.title
+
 
 class Cart(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -25,6 +28,9 @@ class Cart(models.Model):
     quantity = models.SmallIntegerField()
     unit_price = models.DecimalField(max_digits=5, decimal_places=2)
     price = models.DecimalField(max_digits=6, decimal_places=2)
+
+    def __str__(self) -> str:
+        return self.user.username
 
     class Meta:
         unique_together = ('menuitem', 'user')

--- a/littleLemon/urls.py
+++ b/littleLemon/urls.py
@@ -11,4 +11,6 @@ urlpatterns = [
     path('groups/delivery-crew/users', views.listAddUsersDeliveryCrewGroup),
     path('groups/delivery-crew/users/<int:id>',
          views.removeUserDeliveryCrewGroup),
+    # path('cart/menu-items', views.CartCustomerManagement.as_view()),
+    path('cart/menu-items', views.cartCustomerManagement),
 ]


### PR DESCRIPTION
Added API endpoints for cart management, allowing customers to retrieve, add, and delete items from their cart.

- GET /api/cart/menu-items: Returns current items in the cart for the authenticated user token.
- POST /api/cart/menu-items: Adds the menu item to the cart, calculates total price, and associates the user.
- DELETE /api/cart/menu-items: Deletes all menu items from the cart created by the current user token.